### PR TITLE
Import StringIO from io module when running on Python3

### DIFF
--- a/randomAccessReader/__init__.py
+++ b/randomAccessReader/__init__.py
@@ -10,7 +10,10 @@ Inspired by: http://stackoverflow.com/a/35785248/1857802 and http://stackoverflo
 # =============
 
 import csv
-from io import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import six
 
 # ==========


### PR DESCRIPTION
from randomAccessReader import RandomAccessReader
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-f34837a7c413> in <module>()
----> 1 from randomAccessReader import RandomAccessReader

~/.local/share/virtualenvs/pipenv-UfFdSzCR/lib/python3.6/site-packages/randomAccessReader/__init__.py in <module>()
     11 
     12 import csv
---> 13 import StringIO
     14 
     15 # ==========

ModuleNotFoundError: No module named 'StringIO'